### PR TITLE
fix: iterate only over phenotypes w/ >= 1 gene to keep

### DIFF
--- a/splice_event_annotation.R
+++ b/splice_event_annotation.R
@@ -71,7 +71,9 @@ sqd$merge_id = ""
 sqd$merge_name = ""
 sqd$merge_type = ""
 sqd$merge_OS = FALSE
-for (i in 1:nrow(sqd)) {
+# Only iterate over rows in which keep_genes is not blank, therefore informative.
+non_blank <- which(sqd$keep_genes != "")
+for (i in non_blank) {
     mergeids = unlist(str_split(sqd[i,]$keep_genes,","))
     ## Order mergeids and supp by protein coding first, then others? (as other usually lncRNA)
     types = genes[mergeids,]$gene_type


### PR DESCRIPTION
WHY IS THIS CHANGE NEEDED?:
- when running splice_event_annotation.R, an error was raised: sum(samestrand)>0 comparison could not be made because sum(samestrand) is empty.
- this is because some elements of sqd$keep_genes have the value "", which then leads to a samestrand value of NA, making R unable to perform the comparison.

HOW DOES THE CHANGE SOLVE THE PROBLEM?:
- identified which sqd$keep_genes elements were empty, then used this list of indices to tell the loop which rows of sqd to iterate over.

EVIDENCE THAT COMMIT WORKS:
- output tsv file is now written, with annotations for each phenotype id